### PR TITLE
Path reorg

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,15 +4,15 @@ log_level = "INFO" # Define the logging level here. Options are: DEBUG, INFO, WA
 seed = 21122023    # Random seed for reproducibility
 
 [io]
-base_dir = "/Volumes/sep22/home/wet_lab/_Experiments/009_ST_Xenium" # Base directory for the project (relative to the current working directory)
-data_dir = "data"                                                   # Directory where the input data is stored
-output_dir = "out"                                                  # Directory where the output will be saved (relative to data_dir)
-output_data_dir = "data"                                            # Directory where processed data will be saved (relative to output_dir)
-xenium_dir = "xenium"                                               # Directory containing Xenium data (relative to data_dir)
-zarr_dir = "xenium.zarr"                                            # Directory where Zarr data will be stored (relative to data_dir)
-adata_dir = "adata"                                                 # Directory where AnnData objects will be saved (relative to output_data_dir)
-area_path = "selected_cells_stats.csv"                              # Path to the CSV file containing selected cells statistics (relative to data_dir)
-logging_path = "logs"                                               # Directory where logs will be saved (relative to output_dir)
+base_dir = "."                    # Base directory for the project (relative to the current working directory)
+data_dir = "data"                 # Directory where the input data is stored (relative to base_dir)
+xenium_dir = "xenium_raw"         # Directory containing Xenium data (relative to data_dir)
+output_data_dir = "out_data"      # Directory where processed data will be saved (relative to data_dir)
+adata_dir = "adata"               # Directory where AnnData objects will be saved (relative to output_data_dir)
+zarr_dir = "xenium.zarr"          # Directory where Zarr data will be stored (relative to output_data_dir)
+output_dir = "out_test"           # Directory where the output will be saved (relative to base_dir)
+path = "selected_cells_stats.csv" # Path to the CSV file containing selected cells statistics (relative to data_dir)
+logging_path = "logs"             # Directory where logs will be saved (relative to output_dir)
 
 [modules.subsample_data]
 module_name = "0.5_subsample_data" # Name of the module - will be used in the output directory name

--- a/src/recode_st/config.py
+++ b/src/recode_st/config.py
@@ -218,7 +218,7 @@ class IOConfig(BaseModel):
 
         # Output paths
         self.output_dir = self.base_dir / self.output_dir
-        self.output_data_dir = self.output_dir / self.output_data_dir
+        self.output_data_dir = self.data_dir / self.output_data_dir
         self.zarr_dir = self.output_data_dir / self.zarr_dir
         self.adata_dir = self.output_data_dir / self.adata_dir
         self.logging_dir = self.output_dir / self.logging_dir


### PR DESCRIPTION
Reorganizing the paths so can run python on both locally and HPC by only changing the base directory. 

Organization of directories as follows:
```
BASE_DIR
├── data
│   ├── xenium_raw
│   ├── out_data
│   │   ├── adata
│   │   └── xenium.zarr
│   └── selected_cells_stats.csv
└── out_test
    └── logs
```

`xenium_raw`: run folder which also contains the output folders from the machine
`out_data`: contains the adata following running module 0_format
`out_test`: contains output from analysis modules